### PR TITLE
allow message_created even to trigger another automation

### DIFF
--- a/app/listeners/automation_rule_listener.rb
+++ b/app/listeners/automation_rule_listener.rb
@@ -18,16 +18,18 @@ class AutomationRuleListener < BaseListener
   def message_created(event)
     message = event.data[:message]
 
-    return if ignore_message_created_event?(event)
+    return if message.activity? || message.auto_reply_email?
 
     account = message.try(:account)
     changed_attributes = event.data[:changed_attributes]
+    originating_rule = performed_by_automation?(event) ? event.data[:performed_by] : nil
 
     return unless rule_present?('message_created', account)
 
     rules = current_account_rules('message_created', account)
 
     rules.each do |rule|
+      next if originating_rule && rule.id == originating_rule.id
       next unless automation_sources_match?(rule, message.conversation)
 
       conditions_match = ::AutomationRules::ConditionsFilterService.new(rule, message.conversation,
@@ -81,11 +83,6 @@ class AutomationRuleListener < BaseListener
   def ignore_auto_reply_event?(event)
     conversation = event.data[:conversation]
     conversation.additional_attributes['auto_reply'].present?
-  end
-
-  def ignore_message_created_event?(event)
-    message = event.data[:message]
-    performed_by_automation?(event) || message.activity? || message.auto_reply_email?
   end
 
   def automation_sources_match?(rule, conversation)


### PR DESCRIPTION
# Pull Request Template

## Description

Please include a summary of the change and issue(s) fixed. Also, mention relevant motivation, context, and any dependencies that this change requires.
Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.


## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed duplicate automation rule execution. Automation rules previously could be triggered multiple times for the same message. The system now correctly prevents rules from re-processing the same message, ensuring each rule executes only once per message event.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->