### PR TITLE
feat: added closing from no category

### DIFF
--- a/app/controllers/api/v1/accounts/conversations_controller.rb
+++ b/app/controllers/api/v1/accounts/conversations_controller.rb
@@ -223,6 +223,7 @@ class Api::V1::Accounts::ConversationsController < Api::V1::Accounts::BaseContro
   def set_resolution_custom_attributes
     attrs = {}
     attrs['close_topics'] = params[:close_topics] if params[:close_topics].present?
+    attrs['closed_from_no_category'] = true if ActiveModel::Type::Boolean.new.cast(params[:closed_from_no_category])
     attrs['resolved_at'] = Time.current.iso8601 if attrs.any? || params[:resolution_reason].present? || params[:custom_resolution_reason].present?
     @conversation.custom_attributes = @conversation.custom_attributes.merge(attrs) if attrs.any?
   end

--- a/app/javascript/dashboard/api/inbox/conversation.js
+++ b/app/javascript/dashboard/api/inbox/conversation.js
@@ -58,11 +58,13 @@ class ConversationApi extends ApiClient {
     status,
     snoozedUntil = null,
     closeTopics = null,
+    closedFromNoCategory = false,
   }) {
     return axios.post(`${this.url}/${conversationId}/toggle_status`, {
       status,
       snoozed_until: snoozedUntil,
       close_topics: closeTopics,
+      closed_from_no_category: closedFromNoCategory,
     });
   }
 

--- a/app/javascript/dashboard/components/ConversationCloseTopicsModal.vue
+++ b/app/javascript/dashboard/components/ConversationCloseTopicsModal.vue
@@ -15,6 +15,10 @@ const props = defineProps({
     type: Boolean,
     default: false,
   },
+  fromNoCategory: {
+    type: Boolean,
+    default: false,
+  },
 });
 
 const emit = defineEmits(['close', 'success']);
@@ -68,6 +72,10 @@ watch(
   newVal => {
     isOpen.value = newVal;
     if (newVal) {
+      if (props.fromNoCategory) {
+        selectedTopics.value = ['other'];
+        return;
+      }
       const conversation = store.getters.getConversationById(
         props.conversationId
       );
@@ -111,6 +119,7 @@ const submitTopics = async () => {
       status: 'resolved',
       closeTopics:
         selectedTopics.value.length > 0 ? selectedTopics.value : null,
+      closedFromNoCategory: props.fromNoCategory,
     });
 
     await store.dispatch('updateCustomAttributes', {

--- a/app/javascript/dashboard/components/buttons/ResolveAction.vue
+++ b/app/javascript/dashboard/components/buttons/ResolveAction.vue
@@ -22,6 +22,7 @@ const { t } = useI18n();
 const isLoading = ref(false);
 const showCloseTopicsModal = ref(false);
 const closeConversationId = ref(null);
+const closeFromNoCategory = ref(false);
 
 const currentChat = computed(() => getters.getSelectedChat.value);
 
@@ -42,8 +43,10 @@ const isStandBy = computed(
 );
 
 const showOpenButton = computed(() => {
-  return isPending.value || isSnoozed.value || isStandBy.value;
+  return isSnoozed.value || isStandBy.value;
 });
+
+const showResolveButton = computed(() => isOpen.value || isPending.value);
 
 const getConversationParams = () => {
   const allConversations = document.querySelectorAll(
@@ -68,6 +71,7 @@ const getConversationParams = () => {
 const toggleStatus = (status, snoozedUntil) => {
   if (status === wootConstants.STATUS_TYPE.RESOLVED) {
     closeConversationId.value = currentChat.value.id;
+    closeFromNoCategory.value = isPending.value;
     showCloseTopicsModal.value = true;
     return;
   }
@@ -88,11 +92,13 @@ const toggleStatus = (status, snoozedUntil) => {
 const closeTopicsModal = () => {
   showCloseTopicsModal.value = false;
   closeConversationId.value = null;
+  closeFromNoCategory.value = false;
 };
 
 const onCloseTopicsSuccess = () => {
   showCloseTopicsModal.value = false;
   closeConversationId.value = null;
+  closeFromNoCategory.value = false;
   useAlert(t('CONVERSATION.CHANGE_STATUS'));
 };
 
@@ -135,7 +141,7 @@ useEmitter(CMD_RESOLVE_CONVERSATION, onCmdResolveConversation);
 <template>
   <div class="relative flex items-center justify-end resolve-actions">
     <Button
-      v-if="isOpen"
+      v-if="showResolveButton"
       :label="t('CONVERSATION.HEADER.RESOLVE_ACTION')"
       size="sm"
       color="slate"
@@ -162,6 +168,7 @@ useEmitter(CMD_RESOLVE_CONVERSATION, onCmdResolveConversation);
       v-if="showCloseTopicsModal"
       :show="showCloseTopicsModal"
       :conversation-id="closeConversationId"
+      :from-no-category="closeFromNoCategory"
       @close="closeTopicsModal"
       @success="onCloseTopicsSuccess"
     />

--- a/app/javascript/dashboard/store/modules/conversations/actions.js
+++ b/app/javascript/dashboard/store/modules/conversations/actions.js
@@ -278,7 +278,13 @@ const actions = {
 
   toggleStatus: async (
     { commit, dispatch },
-    { conversationId, status, snoozedUntil = null, closeTopics = null }
+    {
+      conversationId,
+      status,
+      snoozedUntil = null,
+      closeTopics = null,
+      closedFromNoCategory = false,
+    }
   ) => {
     try {
       const {
@@ -293,6 +299,7 @@ const actions = {
         status,
         snoozedUntil,
         closeTopics,
+        closedFromNoCategory,
       });
       commit(types.CHANGE_CONVERSATION_STATUS, {
         conversationId,

--- a/app/models/conversation.rb
+++ b/app/models/conversation.rb
@@ -172,7 +172,7 @@ class Conversation < ApplicationRecord
     resolution_reason_will_change!
     self.resolution_reason = nil
     custom_attributes_will_change!
-    self.custom_attributes = custom_attributes&.except('custom_resolution_reason', 'close_topics', 'resolved_at') || {}
+    self.custom_attributes = custom_attributes&.except('custom_resolution_reason', 'close_topics', 'resolved_at', 'closed_from_no_category') || {}
   end
 
   def toggle_priority(priority = nil)


### PR DESCRIPTION
# Pull Request Template

## Description

Please include a summary of the change and issue(s) fixed. Also, mention relevant motivation, context, and any dependencies that this change requires.
Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.


## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added tracking for conversations closed from a "no category" state to improve resolution metadata.
  * Enhanced close topics modal with specialized handling for conversations without assigned categories.

* **Bug Fixes**
  * Expanded resolve button visibility to display when conversations are in open or pending states.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cn-corporation/chatwoot/pull/252)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->