### PR TITLE
added auto open of dialogue on aml team

### DIFF
--- a/app/models/conversation.rb
+++ b/app/models/conversation.rb
@@ -243,6 +243,7 @@ class Conversation < ApplicationRecord
   def execute_after_update_commit_callbacks
     handle_resolved_status_change
     assign_support_247_team_on_status_change
+    open_stand_by_conversation_on_aml_assignment
     notify_status_change
     create_activity
     notify_conversation_updation
@@ -280,12 +281,28 @@ class Conversation < ApplicationRecord
     # rubocop:enable Rails/SkipsModelValidations
   end
 
+  def open_stand_by_conversation_on_aml_assignment
+    return unless saved_change_to_team_id?
+
+    aml_team_id = account.settings&.dig('aml_team_id')
+    return if aml_team_id.blank?
+    return unless team_id == aml_team_id
+    return unless stand_by?
+
+    update!(status: :open)
+  end
+
+  # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
   def should_assign_support_247_team?
     return false if account.settings&.dig('support_247_team_id').blank?
     return false if account.settings&.dig('support_l1_enabled') && account.settings&.dig('support_line_1_active')
 
+    aml_team_id = account.settings&.dig('aml_team_id')
+    return false if aml_team_id.present? && team_id == aml_team_id
+
     true
   end
+  # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 
   def ensure_snooze_until_reset
     self.snoozed_until = nil unless snoozed?

--- a/spec/models/conversation_spec.rb
+++ b/spec/models/conversation_spec.rb
@@ -979,4 +979,72 @@ RSpec.describe Conversation do
       expect(reply_events.count).to eq(0)
     end
   end
+
+  describe 'AML auto-open behavior' do
+    let!(:account) { create(:account) }
+    let!(:support_team) { create(:team, account: account) }
+    let!(:aml_team) { create(:team, account: account) }
+    let(:inbox) { create(:inbox, account: account) }
+    let(:contact) { create(:contact, account: account) }
+    let(:contact_inbox) { create(:contact_inbox, contact: contact, inbox: inbox) }
+
+    before do
+      account.settings['support_247_team_id'] = support_team.id
+      account.settings['aml_team_id'] = aml_team.id
+      account.save!
+    end
+
+    describe '#should_assign_support_247_team?' do
+      it 'is false when the conversation is on the AML team' do
+        conversation = create(:conversation, account: account, inbox: inbox,
+                                             contact: contact, contact_inbox: contact_inbox,
+                                             team: aml_team)
+        expect(conversation.send(:should_assign_support_247_team?)).to be(false)
+      end
+
+      it 'is true when the conversation is on a non-AML team' do
+        conversation = create(:conversation, account: account, inbox: inbox,
+                                             contact: contact, contact_inbox: contact_inbox,
+                                             team: support_team)
+        expect(conversation.send(:should_assign_support_247_team?)).to be(true)
+      end
+    end
+
+    describe 'auto-open on AML team assignment' do
+      let!(:conversation) do
+        create(:conversation, account: account, inbox: inbox, contact: contact,
+                              contact_inbox: contact_inbox, status: 'stand_by', team: support_team)
+      end
+
+      it 'opens a stand_by (waiting) conversation when the team changes to the AML team' do
+        conversation.update!(team: aml_team)
+        expect(conversation.reload.status).to eq('open')
+      end
+
+      it 'keeps the AML team assigned after opening (does not restore support 24/7 team)' do
+        conversation.update!(team: aml_team)
+        expect(conversation.reload.team_id).to eq(aml_team.id)
+      end
+
+      it 'leaves the conversation in stand_by when the team changes to a non-AML team' do
+        other_team = create(:team, account: account)
+        conversation.update!(team: other_team)
+        expect(conversation.reload.status).to eq('stand_by')
+      end
+
+      it 'does not change status when an already-open conversation is assigned to AML' do
+        open_conversation = create(:conversation, account: account, inbox: inbox, contact: contact,
+                                                  contact_inbox: contact_inbox, status: 'open', team: support_team)
+        open_conversation.update!(team: aml_team)
+        expect(open_conversation.reload.status).to eq('open')
+      end
+
+      it 'does not open a pending conversation assigned to AML (only stand_by qualifies)' do
+        pending_conversation = create(:conversation, account: account, inbox: inbox, contact: contact,
+                                                     contact_inbox: contact_inbox, status: 'pending', team: support_team)
+        pending_conversation.update!(team: aml_team)
+        expect(pending_conversation.reload.status).to eq('pending')
+      end
+    end
+  end
 end


### PR DESCRIPTION
# Pull Request Template

## Description

Please include a summary of the change and issue(s) fixed. Also, mention relevant motivation, context, and any dependencies that this change requires.
Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.


## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Conversations assigned to a configured AML team now reopen automatically when they are in stand-by status.
  * 24/7 support team assignment now avoids overriding conversations already routed to the AML team.
  * Status changes are now more consistent when conversations move between AML and non-AML teams, including open and pending conversations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->